### PR TITLE
Flight constraints/ fix for registering on phone

### DIFF
--- a/webapp/src/views/EditFlightPage/EditFlightPage.vue
+++ b/webapp/src/views/EditFlightPage/EditFlightPage.vue
@@ -187,6 +187,20 @@
           isComplete = false;
           this.alertMissingMessage += 'Set a flight area (click the pen button on the far right to set points on the map),'
         }
+        var startTime = new Date(this.flight.starts_at)
+        var endTime = new Date(this.flight.ends_at)
+        var duration = endTime - startTime
+        startTime = startTime.getHours() + ":" + startTime.getMinutes()
+        endTime = endTime.getHours() + ":" + endTime.getMinutes()
+        if (startTime == endTime) {
+          isComplete = false;
+          this.alertMissingMessage += 'The start time and date time cannot be the same time,'
+        }
+        //if the flight is longer than 12 hours
+        if (duration > (1000*60*60*12)) {
+          isComplete = false;
+          this.alertMissingMessage += 'The flight time is too long. Please check the time again,'
+        }
         if (!isComplete) {
           this.alertMissingMessage = this.alertMissingMessage.slice(0,-1).split(',')
         }

--- a/webapp/src/views/LandingPage/LandingPage.vue
+++ b/webapp/src/views/LandingPage/LandingPage.vue
@@ -15,7 +15,7 @@
           </v-flex>
         </v-layout>
         <v-spacer/>
-        <v-flex class="hidden-xs-only">
+        <v-flex>
           <reg-step
           v-on:snackbar="_snackbar"
           />

--- a/webapp/src/views/NewFlightPage/NewFlightPage.vue
+++ b/webapp/src/views/NewFlightPage/NewFlightPage.vue
@@ -206,6 +206,20 @@
           isComplete = false;
           this.alertMissingMessage += 'Set a flight area (click the pen button on the far right to set points on the map),'
         }
+        var startTime = new Date(this.flight.starts_at)
+        var endTime = new Date(this.flight.ends_at)
+        var duration = endTime - startTime
+        startTime = startTime.getHours() + ":" + startTime.getMinutes()
+        endTime = endTime.getHours() + ":" + endTime.getMinutes()
+        if (startTime == endTime) {
+          isComplete = false;
+          this.alertMissingMessage += 'The start time and date time cannot be the same time,'
+        }
+        //if the flight is longer than 12 hours
+        if (duration > (1000*60*60*12)) {
+          isComplete = false;
+          this.alertMissingMessage += 'The flight time is too long. Please check the time again,'
+        }
         if (!isComplete) {
           this.alertMissingMessage = this.alertMissingMessage.slice(0,-1).split(',')
         }


### PR DESCRIPTION
For issue #11 
Prevents users from registering flights longer than 12 hours or if the start time is the same as the end time

Also made the registration component show up for mobile devices to help out on issue #25 